### PR TITLE
Fixed bug when serving coroutines

### DIFF
--- a/aiorpc/server.py
+++ b/aiorpc/server.py
@@ -155,7 +155,7 @@ async def serve(reader, writer):
             ret = method.__call__(*args)
             if asyncio.iscoroutine(ret):
                 _logger.debug("start to wait_for")
-                ret = asyncio.wait_for(ret, _timeout)
+                ret = await asyncio.wait_for(ret, _timeout)
             _logger.debug('calling {} completed. result: {}'.format(str(method), str(ret)))
         except Exception as e:
             await _send_error(conn, str(e), msg_id)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='aiorpc',
-    version='0.1.2',
+    version='0.1.3',
     description='A fast RPC library based on asyncio and MessagePack',
     long_description=open('README.rst').read(),
     author='Cholerae Hu',


### PR DESCRIPTION
Fixed error `Exception can't serialize <generator object wait_for at 0x7f5b00749410> raised when _send_result <generator object wait_for at 0x7f5b00749410> to ('127.0.0.1', 57898)` when serving coroutines by adding await syntax to asyncio.await_for on aiorpc.server.serve

In addition, it would be good if documentation could be uploaded again.