### PR TITLE
Add client async context managers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,17 @@ RPC client
     loop.run_until_complete(do(client))
     client.close()
 
+aiorpc client can also be used as an async context manager:
+
+.. code-block:: python
+
+    async def do():
+        async with RPCClient('127.0.0.1', 6000) as client:
+            ret = await client.call('echo', 'message')
+            print("{}\n".format(ret))
+
+
+
 Performance
 -----------
 

--- a/aiorpc/server.py
+++ b/aiorpc/server.py
@@ -45,6 +45,7 @@ def msgpack_init(**kwargs):
     :param kwargs: See http://pythonhosted.org/msgpack-python/api.html
             default:
             pack_encoding='utf-8'
+            pack_params=dict()
             unpack_encoding='utf-8'
             unpack_params=dict(use_list=False)
     :return: None

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='aiorpc',
-    version='0.1.3',
+    version='0.1.4',
     description='A fast RPC library based on asyncio and MessagePack',
     long_description=open('README.rst').read(),
     author='Cholerae Hu',

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -63,6 +63,14 @@ def test_call():
     loop.run_until_complete(_test_call())
 
 
+def test_context_manager():
+    async def _test_context_manager():
+        async with RPCClient(HOST, PORT) as client:
+            ret = await client.call('echo', 'message')
+            eq_('message', ret)
+    loop.run_until_complete(_test_context_manager())
+
+
 @raises(RPCError)
 def test_call_server_side_exception():
     async def _test_call_server_side_exception():


### PR DESCRIPTION
Added the possibility the use async context managers which will be responsible to establish a new connection on `__aenter__` and close it on `__aexit__`. 

As also documented in the readme file, client can now be used as follows:
```
async with RPCClient('127.0.0.1', 6000) as client:
    ret = await client.call('echo', 'message')
```

Use of context managers on the client could solve the problem of client not closing connections reported in issue: [#5](https://github.com/choleraehyq/aiorpc/issues/5#issue-354053273)

The client will now also start a new connection if a new `call` is scheduled and current connection is closed.