### PR TITLE
Remove uvloop dependencies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -91,7 +91,8 @@ aiorpc with `uvloop <https://github.com/MagicStack/uvloop>`_ significantly outpe
 
 .. code-block:: bash
 
-    % python benchmarks/benchmark_aiorpc.py
+    % pip install uvloop
+    % python benchmarks/benchmark_aiorpc_inet.py
     call: 2236 qps
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-uvloop==0.14.0
 msgpack==1.0.0
 nose==1.3.7

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     ],
     install_requires=[
         'msgpack',
-        'uvloop',
     ],
     tests_require=[
         'nose',

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -4,7 +4,6 @@
 import asyncio
 
 from nose.tools import *
-import uvloop
 
 from aiorpc import RPCClient, register, serve, register_class
 from aiorpc.exceptions import RPCError, EnhancedRPCError
@@ -53,7 +52,7 @@ def raise_error():
 def set_up_inet_server():
     global loop, inet_server
     if not loop:
-        loop = uvloop.new_event_loop()
+        loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     coro = asyncio.start_server(serve, HOST, PORT)
     inet_server = loop.run_until_complete(coro)
@@ -61,7 +60,7 @@ def set_up_inet_server():
 def set_up_unix_server():
     global loop, unix_server
     if not loop:
-        loop = uvloop.new_event_loop()
+        loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
     coro = asyncio.start_unix_server(serve, PATH)
     unix_server = loop.run_until_complete(coro)


### PR DESCRIPTION
This PR leaves uvloop as an optional dependency. Examples, benchmarks and documentations still recommend uvloop, but dependency setups and tests won't use uvloop anymore.

Practical reasons for this change include Windows (duh) and users for some other loop implementations (e.g., qasync).

Note: to support tests on Windows, not only uvloop but unit tests related to unix sockets should be removed as well. This change is not included in this PR.