### PR TITLE
Enable non tuple response

### DIFF
--- a/aiorpc/client.py
+++ b/aiorpc/client.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import asyncio
+import collections
 import logging
 import msgpack
 
@@ -83,7 +84,7 @@ class RPCClient:
             raise e
 
         for response in responses:
-            if not isinstance(response, tuple):
+            if not isinstance(response, collections.Iterable):
                 logging.debug('Protocol error, received unexpected data: %r', response)
                 raise RPCProtocolError('Invalid protocol')
 

--- a/examples/client.py
+++ b/examples/client.py
@@ -6,9 +6,11 @@ import uvloop
 async def do(cli):
     ret = await client.call('echo', 'message')
     print("{}\n".format(ret))
+    ret = await client.call('get_dict')
+    print("{}\n".format(ret))
 
 loop = uvloop.new_event_loop()
 asyncio.set_event_loop(loop)
-client = RPCClient('127.0.0.1', 6000)
+client = RPCClient('127.0.0.1', 6000, unpack_params={'strict_map_key': False})
 loop.run_until_complete(do(client))
 client.close()

--- a/examples/server.py
+++ b/examples/server.py
@@ -7,9 +7,13 @@ import uvloop
 def echo(msg):
     return msg
 
+def get_dict():
+    return {1: 2}
+
 loop = uvloop.new_event_loop()
 asyncio.set_event_loop(loop)
 register("echo", echo)
+register("get_dict", get_dict)
 coro = asyncio.start_server(serve, '127.0.0.1', 6000, loop=loop)
 server = loop.run_until_complete(coro)
 

--- a/tests/test_rpc.py
+++ b/tests/test_rpc.py
@@ -49,6 +49,10 @@ def raise_error():
     raise Exception('error msg')
 
 
+def get_dict():
+    return {1: 2}
+
+
 def set_up_inet_server():
     global loop, inet_server
     if not loop:
@@ -69,6 +73,7 @@ def register_handlers():
     register('echo', echo)
     register('echo_delayed', echo_delayed)
     register('raise_error', raise_error)
+    register('get_dict', get_dict)
     register_class(my_class)
 
 
@@ -194,6 +199,17 @@ def test_unix_call_once():
         ret = await client.call_once('echo', 'message again')
 
         eq_('message again', ret)
+
+    loop.run_until_complete(_test_call())
+
+
+# Somtimes tuple, sometimes list
+def test_response_types():
+    async def _test_call():
+        client = RPCClient(path=PATH, unpack_params={'strict_map_key': False})
+        ret = await client.call_once('get_dict')
+
+        eq_({1: 2}, ret)
 
     loop.run_until_complete(_test_call())
 


### PR DESCRIPTION
Hey, for some reason, when one uses `client = RPCClient(path=PATH, unpack_params={'strict_map_key': False})` the responses are not tuples, but lists, and [this](https://github.com/choleraehyq/aiorpc/blob/master/aiorpc/client.py#L86) test fails. This PR tries to remedy that.
The use case is e.g. dictionaries with non-string keys.